### PR TITLE
Improve security around the CSR/CSR Attributes files.

### DIFF
--- a/nd-puppet/metadata.rb
+++ b/nd-puppet/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@nextdoor.com'
 license          'Apache 2.0'
 description      'Installs/Configures Puppet'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.6'
 
 depends "marker"
 depends "machine_tag"
@@ -42,6 +42,17 @@ attribute "nd-puppet/config/facts",
     "A list of key=value custom puppet facts that will be stored in " +
     "/etc/facter/facts.d/nd-puppet.txt and available to Puppet as " +
     "facts for your manifest compilation. eg: my_cname=foobar",
+  :required     => "optional",
+  :type         => "array",
+  :category     => "Nextdoor: Puppet Settings",
+  :recipes      => [ "nd-puppet::default", "nd-puppet::config" ]
+
+attribute "nd-puppet/config/trusted_facts",
+  :display_name => "Custom Puppet Trusted Facts",
+  :description  =>
+    "A list of key=value custom puppet facts that will be stored in " +
+    "in the CSR for the client. Each fact should be listed with the OID " +
+    "and the value in a key=value format. Ie. 1.3.6.1.4.1.34380.1.2.1=Foo",
   :required     => "optional",
   :type         => "array",
   :category     => "Nextdoor: Puppet Settings",

--- a/nd-puppet/templates/default/csr_attributes.yaml.erb
+++ b/nd-puppet/templates/default/csr_attributes.yaml.erb
@@ -1,4 +1,0 @@
-custom_attributes:
-  1.2.840.113549.1.9.7: <%= @challenge_password %>
-extension_requests:
-  pp_preshared_key: <%= @pp_preshared_key %>

--- a/nd-puppet/templates/default/run.sh.erb
+++ b/nd-puppet/templates/default/run.sh.erb
@@ -22,9 +22,9 @@ REPORT=<%= @report %>
 hostname --file /etc/hostname
 export DOMAIN=$(domainname)
 export HOSTNAME=$(cat /etc/hostname)
-echo "FQDN: ${HOSTNAME}.${DOMAIN}"
 
 # Unchanging variables ..
+CSR_ATTRIBUTES=/etc/puppet/csr_attributes.yaml
 AGENT_LOCK_FILE=/var/lib/puppet/state/agent_catalog_run.lock
 RUN_SUMMARY_FILE=/var/lib/puppet/state/last_run_summary.yaml
 
@@ -80,7 +80,7 @@ for (( C=1; C<=$RETRIES; C++ )); do
   # we purge the state files. This is because they will actually write out
   # 'changed: 0' to a state file. The simplest solution is to purge the
   # last run summary file so that our above-check doesnt read it.
-  $CMD && exit 0 || rm -f $RUN_SUMMARY_FILE
+  $CMD && exit 0 || rm -f $RUN_SUMMARY_FILE $CSR_ATTRIBUTES
 done
 
 # If we get here, then the 'exit 0' above never succeeded and we must have


### PR DESCRIPTION
Ensure that the CSR and CSR_Attributes files are deleted after they are
consumed. This gets rid of the challengePassword so that individual
hosts don't keep it around.