### PR TITLE
lock right_api_client gem to specific version for ubuntu12

### DIFF
--- a/nd-puppet/recipes/install.rb
+++ b/nd-puppet/recipes/install.rb
@@ -31,9 +31,19 @@ end
 
 # Install the RightScale API Gems on the system for use when
 # puppet interacts with the RightScale API.
-gem_package "right_api_client" do
-  gem_binary "/usr/bin/gem"
-  options "--no-ri --no-rdoc"
+
+case node['platform_version']
+when '12.04'
+  gem package "right_api_client" do
+    gem_binary "/usr/bin/gem"
+    options "--no-ri --no-rdoc"
+    version "1.5.26"
+  end
+else
+  gem package "right_api_client" do
+    gem_binary "/usr/bin/gem"
+    options "--no-ri --no-rdoc"
+  end
 end
 
 # Download the Puppetlabs Apt package that installs their repo

--- a/nd-puppet/recipes/install.rb
+++ b/nd-puppet/recipes/install.rb
@@ -24,7 +24,7 @@ end
 # specifically come with Ruby 1.8. Mime-types is a dependency
 # for the right_api_client below.
 gem_package "mime-types" do
-  version "1.25"
+  version "1.26"
   gem_binary "/usr/bin/gem"
   options "--no-ri --no-rdoc"
 end


### PR DESCRIPTION
Some dirty conditional logic to lock ubuntu12 to right_api_client v1.5.26. This is not quite DRY but Chef package resource also does seem to support 'version :latest' or 'version:installed'.

@siminm @diranged 